### PR TITLE
Service methods to interact with users

### DIFF
--- a/packages/contracts/contracts/UserRegistry.sol
+++ b/packages/contracts/contracts/UserRegistry.sol
@@ -9,36 +9,31 @@ contract UserRegistry {
     * Events
     */
 
-    event NewUser(uint _index);
+    event NewUser(address _address);
 
     /*
     * Storage
     */
 
-    // Array of all users
-    userStruct[] public users;
+    // Mapping of all users
+    mapping(address => userStruct) public users;
 
     /*
     * Structs
     */
 
     struct userStruct {
-        address owner;
         bytes32 ipfsHash;
+        bool isSet;
     }
 
     /*
     * Modifiers
     */
 
-    modifier isValidUserIndex(uint _index) {
-        require (_index < users.length);
+    modifier isValidUserAddress() {
+        require (users[msg.sender].isSet);
         _;
-    }
-
-    modifier isOwner(uint _index) {
-      require (msg.sender == users[_index].owner);
-      _;
     }
 
     /*
@@ -47,28 +42,13 @@ contract UserRegistry {
 
     /// @dev create(): Create a new user
     /// @param _ipfsHash Hash of data on ipfsHash
-    function create(
+    function set(
         bytes32 _ipfsHash
     )
         public
-        returns (uint)
     {
-        users.push(userStruct(msg.sender, _ipfsHash));
-        NewUser(users.length-1);
-        return users.length;
-    }
-
-    /// @dev create(): Create a new user
-    /// @param _ipfsHash Hash of data on ipfsHash
-    function update(
-        uint _index,
-        bytes32 _ipfsHash
-    )
-        public
-        isValidUserIndex(_index)
-        isOwner(_index)
-    {
-        users[_index].ipfsHash = _ipfsHash;
+        users[msg.sender] = userStruct(_ipfsHash, true);
+        NewUser(msg.sender);
     }
 
     /// @dev create_another(): Create a new user and associates attenstion or proof with user

--- a/packages/contracts/test/TestUserRegistry.js
+++ b/packages/contracts/test/TestUserRegistry.js
@@ -16,28 +16,10 @@ contract('UserRegistry', accounts => {
     instance = await contractDefinition.new({from: accounts[0]});
   });
 
-  it('should be able to create a user', async function() {
-    await instance.create(ipfsHash_1, {from: accounts[0]});
-    let [owner, ipfsHash] = await instance.users(0);
-    assert.equal(owner, accounts[0], 'new user has correct owner')
-    assert.equal(ipfsHash, ipfsHash_1, 'new user has correct ipfsHash')
-  });
-
-  it('should allow owner to update a user', async function() {
-    await instance.create(ipfsHash_1, {from: accounts[0]});
-    await instance.update(0, ipfsHash_2, {from: accounts[0]});
-    let [owner, ipfsHash] = await instance.users(0);
-    assert.equal(ipfsHash, ipfsHash_2, 'ipfsHash has been updated')
-  });
-
-  it('should not allow non-owner to update a user', async function() {
-    await instance.create(ipfsHash_1, {from: accounts[0]});
-    try {
-      await instance.update(0, ipfsHash_2, {from: accounts[1]})
-    } catch (err) {
-      assert.ok(isEVMError(err), 'an EVM error is thrown');
-      let [owner, ipfsHash] = await instance.users(0);
-      assert.equal(ipfsHash, ipfsHash_1, 'ipfsHash has not been updated')
-    }
+  it('should be able to set a user', async function() {
+    await instance.set(ipfsHash_1, {from: accounts[0]});
+    let [ipfsHash, isSet] = await instance.users(accounts[0]);
+    assert.equal(isSet, true, 'user has been set');
+    assert.equal(ipfsHash, ipfsHash_1, 'user has correct ipfsHash');
   });
 });

--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -1,4 +1,5 @@
 import ListingsRegistryContract from '../../contracts/build/contracts/ListingsRegistry.json'
+import UserRegistryContract from '../../contracts/build/contracts/UserRegistry.json'
 import bs58 from 'bs58'
 import contract from 'truffle-contract'
 
@@ -13,6 +14,7 @@ class ContractService {
     ContractService.instance = this
 
     this.listingsRegistryContract = contract(ListingsRegistryContract)
+    this.userRegistryContract = contract(UserRegistryContract)
   }
 
   // Return bytes32 hex string from base58 encoded ipfs hash,
@@ -134,6 +136,40 @@ class ContractService {
             console.error(error)
             reject(error)
           })
+        })
+      })
+    })
+  }
+
+  setUser(ipfsUser) {
+    return new Promise((resolve, reject) => {
+      this.userRegistryContract.setProvider(window.web3.currentProvider)
+      window.web3.eth.getAccounts((error, accounts) => {
+        this.userRegistryContract.deployed().then((instance) => {
+          return instance.set(
+            this.getBytes32FromIpfsHash(ipfsUser),
+            {from: accounts[0]})
+        }).then((result) => {
+          resolve(result)
+        }).catch((error) => {
+          console.error('Error submitting to the Ethereum blockchain: ' + error)
+          reject(error)
+        })
+      })
+    })
+  }
+
+  getUser(userAddress) {
+    return new Promise((resolve, reject) => {
+      this.userRegistryContract.setProvider(window.web3.currentProvider)
+      this.userRegistryContract.deployed().then((instance) => {
+        instance.users(userAddress)
+        .then(([ipfsHash, isSet]) => {
+          resolve(this.getIpfsHashFromBytes32(ipfsHash))
+        })
+        .catch((error) => {
+          console.log(`Error fetching userId: ${userId}`)
+          reject(error)
         })
       })
     })

--- a/packages/origin.js/src/ipfs-service.js
+++ b/packages/origin.js/src/ipfs-service.js
@@ -42,31 +42,51 @@ class IpfsService {
   }
 
   submitListing(formListingJson) {
+    const file = {
+      path: 'listing.json',
+      content: JSON.stringify(formListingJson)
+    }
+    return this.submitFile(file)
+  }
+
+  getListing(ipfsHashStr) {
+    return this.getFile(ipfsHashStr)
+  }
+
+  submitUser(formUserJson) {
+    const file = {
+      path: 'user.json',
+      content: JSON.stringify(formUserJson)
+    }
+    return this.submitFile(file)
+  }
+
+  getUser(ipfsHashStr) {
+    return this.getFile(ipfsHashStr)
+  }
+
+  submitFile(file) {
     return new Promise((resolve, reject) => {
-      const file = {
-        path: 'listing.json',
-        content: JSON.stringify(formListingJson)
-      }
       this.ipfs.files.add([file], (error, response) => {
         if (error) {
           console.error('Can\'t connect to IPFS.')
           console.error(error)
-          reject('Can\'t connect to IPFS. Failure to submit listing to IPFS')
+          reject('Can\'t connect to IPFS. Failure to submit file to IPFS')
           return;
         }
         const file = response[0]
         const ipfsHashStr = file.hash
         if (ipfsHashStr) {
-          this.mapCache.set(ipfsHashStr, formListingJson)
+          this.mapCache.set(ipfsHashStr, file)
           resolve(ipfsHashStr)
         } else {
-          reject('Failure to submit listing to IPFS')
+          reject('Failure to submit file to IPFS')
         }
       })
     })
   }
 
-  getListing(ipfsHashStr) {
+  getFile(ipfsHashStr) {
     return new Promise((resolve, reject) => {
       // Check for cache hit
       if (this.mapCache.has(ipfsHashStr)) {

--- a/packages/origin.js/src/origin-service.js
+++ b/packages/origin.js/src/origin-service.js
@@ -1,6 +1,24 @@
 import contractService from './contract-service'
 import ipfsService from './ipfs-service'
 
+var Ajv = require('ajv')
+var ajv = new Ajv()
+
+// TODO: move this to separate file?
+const userSchema = {
+  "$schema":"http://json-schema.org/draft-06/schema#",
+  "title": "User",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 100
+    }
+  }
+}
+
 class OriginService {
   static instance
 
@@ -41,6 +59,37 @@ class OriginService {
 
   }
 
+  setUser(data) {
+    return new Promise((resolve, reject) => {
+      var validate = ajv.compile(userSchema)
+      if (!validate(data)) {
+        reject('invalid user data')
+      } else {
+        // Submit to IPFS
+        ipfsService.submitUser(data)
+        .then((ipfsHash) => {
+          console.log(`IPFS file created with hash: ${ipfsHash} for data:`)
+          console.log(data)
+
+          // Submit to ETH contract
+          contractService.setUser(
+            ipfsHash)
+          .then((transactionReceipt) => {
+            // Success!
+            console.log(`Submitted to ETH blockchain with transactionReceipt.tx: ${transactionReceipt.tx}`)
+            resolve(transactionReceipt.tx)
+          })
+          .catch((error) => {
+            console.error(error)
+            reject(`ETH Failure: ${error}`)
+          })
+        })
+        .catch((error) => {
+          reject(`IPFS Failure: ${error}`)
+        })
+      }
+    })
+  }
 }
 
 const originService = new OriginService()

--- a/packages/origin.js/src/origin-service.js
+++ b/packages/origin.js/src/origin-service.js
@@ -1,84 +1,9 @@
 import contractService from './contract-service'
 import ipfsService from './ipfs-service'
+import userSchema from './schemas/user.json'
 
 var Ajv = require('ajv')
 var ajv = new Ajv()
-
-// TODO: move this to separate file?
-const userSchema = {
-  "$schema":"http://json-schema.org/draft-06/schema#",
-  "title": "User",
-  "type": "object",
-  "required": ["claims"],
-  "properties": {
-    "claims": {
-      "type": "object",
-      "required": ["name"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "customFields": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["field", "value"],
-            "properties": {
-              "field": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
-    },
-    "attestations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["service", "field", "value", "signature"],
-        "properties": {
-          "service": {
-            "type": "string"
-          },
-          "field": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          },
-          "signature": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "proofs": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["service", "username", "proofString", "proofLink"],
-        "properties": {
-          "service": {
-            "type": "string"
-          },
-          "username": {
-            "type": "string"
-          },
-          "proofString": {
-            "type": "string"
-          },
-          "proofLink": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  }
-}
 
 class OriginService {
   static instance

--- a/packages/origin.js/src/origin-service.js
+++ b/packages/origin.js/src/origin-service.js
@@ -9,12 +9,73 @@ const userSchema = {
   "$schema":"http://json-schema.org/draft-06/schema#",
   "title": "User",
   "type": "object",
-  "required": [],
+  "required": ["claims"],
   "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 3,
-      "maxLength": 100
+    "claims": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "customFields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["field", "value"],
+            "properties": {
+              "field": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "attestations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["service", "field", "value", "signature"],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "proofs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["service", "username", "proofString", "proofLink"],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "proofString": {
+            "type": "string"
+          },
+          "proofLink": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/packages/origin.js/src/origin-service.js
+++ b/packages/origin.js/src/origin-service.js
@@ -59,6 +59,31 @@ class OriginService {
 
   }
 
+  getListing(listingIndex) {
+    return new Promise((resolve, reject) => {
+      let userAddress
+      let listingData
+      contractService.getListing(listingIndex)
+      .then(({ lister, ipfsHash, price, unitsAvailable }) => {
+        userAddress = lister
+        return ipfsService.getListing(ipfsHash)
+      })
+      .then((listingJson) => {
+        listingData = JSON.parse(listingJson).data
+        return contractService.getUser(userAddress)
+      })
+      .then((ipfsHash) => {
+        return ipfsService.getUser(ipfsHash)
+      })
+      .then((userData) => {
+        resolve({ listing: listingData, user: userData })
+      })
+      .catch((error) => {
+        reject(`Error fetching contract or IPFS info for listingId: ${listingIndex}`)
+      })
+    })
+  }
+
   setUser(data) {
     return new Promise((resolve, reject) => {
       var validate = ajv.compile(userSchema)

--- a/packages/origin.js/src/schemas/user.json
+++ b/packages/origin.js/src/schemas/user.json
@@ -1,0 +1,74 @@
+{
+  "$schema":"http://json-schema.org/draft-06/schema#",
+  "title": "User",
+  "type": "object",
+  "required": ["claims"],
+  "properties": {
+    "claims": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "customFields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["field", "value"],
+            "properties": {
+              "field": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "attestations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["service", "field", "value", "signature"],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "proofs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["service", "username", "proofString", "proofLink"],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "proofString": {
+            "type": "string"
+          },
+          "proofLink": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I've added some methods to interact with the user registry contract and IPFS. Maybe this works as a first stab.

This uses a user schema, slightly modified from Josh's gist.

Josh's example:

https://gist.github.com/joshfraser/d411a9e73fe638364a46d91d9aa08838

Modified example:

```
{
	"claims":{
		"name": "Josh",
		"customFields": [
			{
				"field" : "driversLicense",
				"value": "DL1234123"
			}
		]
	},
	"attestations":[
		{
			"service": "civic.com",
			"field": "email",
			"value": "josh@originprotocol.com",
			"signature": "0x1f5df2dbe8ea16700b37f860cb00e6a00cfa7c581f1f5df2dbe8ea16700b3b33f4b4b9b69f945012f7ea7d3febf11eb1b73febf11eb1b78e1adc00093febf11eb1b78e1adc"
		}
	],
	"proofs":[
		{
			"service": "twitter.com",
			"username": "joshfraser",
			"proofString": "Verifying myself: I own ETH wallet 0x123...",
			"proofLink": "https://twitter.com/joshfraser/status/892654623240052737"
		}
	]
}
```

I did test these methods in the demo dapp to  make sure they work. (Would be nice to eventually set up more tests for this library, but that's another issue.)

Refs: #8 