### PR TITLE
Fix two typos

### DIFF
--- a/packages/contracts/contracts/Purchase.sol
+++ b/packages/contracts/contracts/Purchase.sol
@@ -99,7 +99,7 @@ contract Purchase {
   }
 
 
-  function openDisute()
+  function openDispute()
   public
   {
     // Must be buyer or seller

--- a/packages/contracts/test/GasTracker.js
+++ b/packages/contracts/test/GasTracker.js
@@ -1,6 +1,6 @@
 const ENABLE_GAS_TRACKING = process.env.GAS_TRACKING != undefined
 const GAS_COST = process.env.GAS_COST || 4
-const ETH_USD = process.env.GAS_COST || 700
+const ETH_USD = process.env.ETH_USD || 700
 
 // This module shows the actual gas amounts used for each Ethereum transaction.
 // Currently, it just displays the costs inline during the tests as the transactions occur.


### PR DESCRIPTION
- Dispute was misspelled in Purchase contract.
- ETH_USD was loading from the wrong environment variable in the gas tracker.