### PR TITLE
Purchases were being created with the wrong buyer.

### DIFF
--- a/packages/contracts/contracts/Listing.sol
+++ b/packages/contracts/contracts/Listing.sol
@@ -53,7 +53,7 @@ contract Listing {
     require (_unitsToBuy == 1); // HACK
 
     // Create purchase contract
-    Purchase purchaseContract = new Purchase(this);
+    Purchase purchaseContract = new Purchase(this, msg.sender);
 
     // Count units as sold
     unitsAvailable -= _unitsToBuy;

--- a/packages/contracts/contracts/Purchase.sol
+++ b/packages/contracts/contracts/Purchase.sol
@@ -49,11 +49,12 @@ contract Purchase {
   */
 
   function Purchase(
-    address _listingContractAddress
+    address _listingContractAddress,
+    address _buyer
   )
   public
   {
-    buyer = msg.sender;
+    buyer = _buyer;
     listingContract = Listing(_listingContractAddress);
     created = now;
   }

--- a/packages/contracts/test/TestListing.js
+++ b/packages/contracts/test/TestListing.js
@@ -1,4 +1,5 @@
 const contractDefinition = artifacts.require('./Listing.sol')
+const purchaseDefinition = artifacts.require('./Purchase.sol')
 
 // Used to assert error cases
 const isEVMError = function(err) {
@@ -37,18 +38,13 @@ contract('Listing', accounts => {
 
   it('should be able to buy a listing', async function() {
     const unitsToBuy = 1 // TODO: Handle multiple units
-    instance.buyListing(
+    const buyTransaction = await instance.buyListing(
       unitsToBuy,
       { from: accounts[1], value: 6 }
     )
+    const listingPurchasedEvent = buyTransaction.logs.find((e)=>e.event=="ListingPurchased")
+    const purchaseContract = purchaseDefinition.at(listingPurchasedEvent.args._purchaseContract)
 
-    // TODO: How to catch events emitted during test?
-    // https://ethereum.stackexchange.com/questions/15353/how-to-listen-for-contract-events-in-javascript-tests
-    // https://github.com/ethereum/web3.js/issues/1023#issuecomment-350791050
-    // We should test that `Purchase` contract was created and has value
-    // sent to it.
-
-    // console.log(purchaseContract)
     let newUnitsAvailable = await instance.unitsAvailable()
     assert.equal(
       newUnitsAvailable,

--- a/packages/contracts/test/TestListing.js
+++ b/packages/contracts/test/TestListing.js
@@ -12,17 +12,17 @@ const price = 33
 const unitsAvailable = 42
 
 contract('Listing', accounts => {
-  var owner = accounts[0]
-  var notOwner = accounts[1]
+  var seller = accounts[0]
+  var buyer = accounts[1]
   var instance
 
   beforeEach(async function() {
     instance = await contractDefinition.new(
-      owner,
+      seller,
       ipfsHash,
       price,
       unitsAvailable,
-      {from: owner}
+      {from: seller}
     )
   })
 
@@ -40,7 +40,7 @@ contract('Listing', accounts => {
     const unitsToBuy = 1 // TODO: Handle multiple units
     const buyTransaction = await instance.buyListing(
       unitsToBuy,
-      { from: accounts[1], value: 6 }
+      { from: buyer, value: 6 }
     )
     const listingPurchasedEvent = buyTransaction.logs.find((e)=>e.event=="ListingPurchased")
     const purchaseContract = purchaseDefinition.at(listingPurchasedEvent.args._purchaseContract)
@@ -50,6 +50,11 @@ contract('Listing', accounts => {
       newUnitsAvailable,
       (unitsAvailable - unitsToBuy),
       'units available has decreased'
+    )
+
+    assert.equal(
+      buyer,
+      await purchaseContract.buyer()
     )
   })
 

--- a/packages/contracts/test/TestPurchase.js
+++ b/packages/contracts/test/TestPurchase.js
@@ -37,6 +37,7 @@ contract('Purchase', accounts => {
 
     instance = await purchaseContractDefinition.new(
       listingInstance.address,
+      buyer,
       {from: buyer}
     )
   })


### PR DESCRIPTION
Purchases were being created with the wrong buyer.

`msg.sender` is the address of the function *caller*, so in this case, the Purchase contract was recording the buyer as the Listing contract not the user, since the Listing contract was the one that called the constructor.

This also shows how you can fetch a contract from an event fire during a transaction.