### PR TITLE
Refactor user registry to just be a mapping of addresses to ipfs hashes

### DIFF
--- a/packages/contracts/contracts/UserRegistry.sol
+++ b/packages/contracts/contracts/UserRegistry.sol
@@ -16,23 +16,14 @@ contract UserRegistry {
     */
 
     // Mapping of all users
-    mapping(address => userStruct) public users;
-
-    /*
-    * Structs
-    */
-
-    struct userStruct {
-        bytes32 ipfsHash;
-        bool isSet;
-    }
+    mapping(address => bytes32) public users;
 
     /*
     * Modifiers
     */
 
     modifier isValidUserAddress() {
-        require (users[msg.sender].isSet);
+        require (users[msg.sender] == 0);
         _;
     }
 
@@ -47,7 +38,7 @@ contract UserRegistry {
     )
         public
     {
-        users[msg.sender] = userStruct(_ipfsHash, true);
+        users[msg.sender] = _ipfsHash;
         NewUser(msg.sender);
     }
 

--- a/packages/contracts/test/TestUserRegistry.js
+++ b/packages/contracts/test/TestUserRegistry.js
@@ -18,8 +18,7 @@ contract('UserRegistry', accounts => {
 
   it('should be able to set a user', async function() {
     await instance.set(ipfsHash_1, {from: accounts[0]});
-    let [ipfsHash, isSet] = await instance.users(accounts[0]);
-    assert.equal(isSet, true, 'user has been set');
+    let ipfsHash = await instance.users(accounts[0]);
     assert.equal(ipfsHash, ipfsHash_1, 'user has correct ipfsHash');
   });
 });


### PR DESCRIPTION
Simplifies the users mapping in the user registry contract, per the discussion in https://github.com/OriginProtocol/platform/issues/39.