### PR TITLE
Remove obsolete modifier

### DIFF
--- a/packages/contracts/contracts/UserRegistry.sol
+++ b/packages/contracts/contracts/UserRegistry.sol
@@ -19,15 +19,6 @@ contract UserRegistry {
     mapping(address => bytes32) public users;
 
     /*
-    * Modifiers
-    */
-
-    modifier isValidUserAddress() {
-        require (users[msg.sender] == 0);
-        _;
-    }
-
-    /*
     * Public functions
     */
 


### PR DESCRIPTION
Removes obsolete modifier from the user registry contract. (Per @wanderingstan 's comment on https://github.com/OriginProtocol/platform/pull/66.)