### PR TITLE
🚚Move Purchase contract creation out into a library

### DIFF
--- a/packages/contracts/contracts/Listing.sol
+++ b/packages/contracts/contracts/Listing.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.4.11;
 /// @dev An indiviual Origin Listing representing an offer for booking/purchase
 
 import "./Purchase.sol";
+import "./PurchaseLibrary.sol";
 
 contract Listing {
 
@@ -67,7 +68,7 @@ contract Listing {
     require (_unitsToBuy <= unitsAvailable);
 
     // Create purchase contract
-    Purchase purchaseContract = new Purchase(this, msg.sender);
+    Purchase purchaseContract = PurchaseLibrary.newPurchase(this, msg.sender);
 
     // Count units as sold
     unitsAvailable -= _unitsToBuy;

--- a/packages/contracts/contracts/PurchaseLibrary.sol
+++ b/packages/contracts/contracts/PurchaseLibrary.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.11;
+
+/// @title PurchaseLibrary
+/// @dev An collection of helper tools for a purchase
+
+import "./Purchase.sol";
+import "./Listing.sol";
+
+library PurchaseLibrary {
+
+    function newPurchase(Listing listing, address _buyer)
+    public
+    returns (Purchase purchase)
+    {
+        purchase = new Purchase(listing, _buyer);
+    }
+    
+}

--- a/packages/contracts/migrations/2_deploy_contracts.js
+++ b/packages/contracts/migrations/2_deploy_contracts.js
@@ -1,7 +1,12 @@
 var ListingsRegistry = artifacts.require("./ListingsRegistry.sol");
+var Listing = artifacts.require("./Listing.sol");
 var UserRegistry = artifacts.require("./UserRegistry.sol");
+var PurchaseLibrary = artifacts.require("./PurchaseLibrary.sol");
 
 module.exports = function(deployer) {
+  deployer.deploy(PurchaseLibrary);
+  deployer.link(PurchaseLibrary, ListingsRegistry)
+  deployer.link(PurchaseLibrary, Listing)
   deployer.deploy(ListingsRegistry);
   deployer.deploy(UserRegistry);
 };


### PR DESCRIPTION
This means that every Listing no longer has to contain the entire Purchase contract binary code. This makes a big cut in the cost to create a new listing.

This also reduces the cost of deploying the ListingRegistry from 4.7 million (on the edge of the limit) to 2.7 million.