### PR TITLE
Fix transactionReceipt variable name

### DIFF
--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -130,9 +130,9 @@ class ContractService {
     return transactionReceipt
   }
 
-  async waitTransactionFinished(transactionReceipt, pollIntervalMilliseconds=1000) {
+  async waitTransactionFinished(transactionHash, pollIntervalMilliseconds=1000) {
     console.log("Waiting for transaction")
-    console.log(transactionReceipt)
+    console.log(transactionHash)
     const blockNumber = await new Promise((resolve, reject) => {
       if (!transactionHash) {
         reject(`Invalid transactionHash passed: ${transactionHash}`)


### PR DESCRIPTION
The transactionHash/transactionReceipt variable must have gotten messed up during a conflict resolution