### PR TITLE
Modularize origin.js

### DIFF
--- a/packages/origin.js/src/index.js
+++ b/packages/origin.js/src/index.js
@@ -1,34 +1,29 @@
-// const contractService = require('./contract-service')
-// const ipfsService = require('./ipfs-service')
-// const originService = require('./origin-service')
-
 import ContractService from "./contract-service"
 import IpfsService from "./ipfs-service"
 import OriginService from "./origin-service"
 import UserRegistryService from "./user-registry-service"
 
-const contractService = new ContractService()
-const ipfsService = new IpfsService()
-const originService = new OriginService({ contractService, ipfsService })
-const userRegistryService = new UserRegistryService()
-
-var origin = {
-  contractService: contractService,
-  ipfsService: ipfsService,
-  originService: originService,
-  userRegistryService: userRegistryService
-}
-
 var resources = {
   listings: require("./resources/listings")
 }
 
-// Give each resource access to the origin services.
-// By having a single origin, its configuration can be changed
-// and all contracts will follow it
-for (var resourceName in resources) {
-  resources[resourceName].origin = origin
-  origin[resourceName] = resources[resourceName]
+class Origin {
+  constructor() {
+    // Give each resource access to the origin services.
+    // By having a single origin, its configuration can be changed
+    // and all contracts will follow it
+    for (let resourceName in resources) {
+      resources[resourceName].origin = this
+      this[resourceName] = resources[resourceName]
+    }
+    this.contractService = new ContractService()
+    this.ipfsService = new IpfsService()
+    this.originService = new OriginService({
+      contractService: this.contractService,
+      ipfsService: this.ipfsService
+    })
+    this.userRegistryService = new UserRegistryService()
+  }
 }
 
-module.exports = origin
+module.exports = Origin

--- a/packages/origin.js/src/index.js
+++ b/packages/origin.js/src/index.js
@@ -9,13 +9,6 @@ var resources = {
 
 class Origin {
   constructor() {
-    // Give each resource access to the origin services.
-    // By having a single origin, its configuration can be changed
-    // and all contracts will follow it
-    for (let resourceName in resources) {
-      resources[resourceName].origin = this
-      this[resourceName] = resources[resourceName]
-    }
     this.contractService = new ContractService()
     this.ipfsService = new IpfsService()
     this.originService = new OriginService({
@@ -23,6 +16,15 @@ class Origin {
       ipfsService: this.ipfsService
     })
     this.userRegistryService = new UserRegistryService()
+
+    // Instantiate each resource and give it access to contracts and IPFS
+    for (let resourceName in resources) {
+      let Resource = resources[resourceName]
+      this[resourceName] = new Resource({
+        contractService: this.contractService,
+        ipfsService: this.ipfsService
+      })
+    }
   }
 }
 

--- a/packages/origin.js/src/index.js
+++ b/packages/origin.js/src/index.js
@@ -1,6 +1,5 @@
 import ContractService from "./contract-service"
 import IpfsService from "./ipfs-service"
-import OriginService from "./origin-service"
 import UserRegistryService from "./user-registry-service"
 
 var resources = {
@@ -11,10 +10,8 @@ class Origin {
   constructor() {
     this.contractService = new ContractService()
     this.ipfsService = new IpfsService()
-    this.originService = new OriginService({
-      contractService: this.contractService,
-      ipfsService: this.ipfsService
-    })
+
+    // TODO: This service is deprecated. Remove once the demo dapp no longer depends on it.
     this.userRegistryService = new UserRegistryService()
 
     // Instantiate each resource and give it access to contracts and IPFS

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -49,10 +49,42 @@ class Listings {
     if (data.name == undefined) {
       throw "You must include a name"
     }
-    return this.origin.originService.submitListing(
-      { formData: data },
-      schemaType
-    )
+
+    let formListing = { formData: data }
+
+    // TODO: Why can't we take schematype from the formListing object?
+    const jsonBlob = {
+      'schema': `http://localhost:3000/schemas/${schemaType}.json`,
+      'data': formListing.formData,
+    }
+
+    let ipfsHash
+    try {
+      // Submit to IPFS
+      ipfsHash = await this.ipfsService.submitFile(jsonBlob)
+    } catch (error) {
+      throw new Error(`IPFS Failure: ${error}`)
+    }
+
+    console.log(`IPFS file created with hash: ${ipfsHash} for data:`)
+    console.log(jsonBlob)
+
+    // Submit to ETH contract
+    const units = 1 // TODO: Allow users to set number of units in form
+    let transactionReceipt
+    try {
+      transactionReceipt = await this.contractService.submitListing(
+        ipfsHash,
+        formListing.formData.price,
+        units)
+    } catch (error) {
+      console.error(error)
+      throw new Error(`ETH Failure: ${error}`)
+    }
+
+    // Success!
+    console.log(`Submitted to ETH blockchain with transactionReceipt.tx: ${transactionReceipt.tx}`)
+    return transactionReceipt
   }
 
   async buy(listingAddress, unitsToBuy, ethToPay) {

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -1,12 +1,12 @@
 // For now, we are just wrapping the methods that are already in
 // contractService and ipfsService.
 
-module.exports = {
-  allIds: async function() {
+class Listings {
+  async allIds() {
     return await this.origin.contractService.getAllListingIds()
-  },
+  }
 
-  getByIndex: async function(listingIndex) {
+  async getByIndex(listingIndex) {
     const contractData = await this.origin.contractService.getListing(
       listingIndex
     )
@@ -35,9 +35,9 @@ module.exports = {
     // TODO: Validation
 
     return listing
-  },
+  }
 
-  create: async function(data, schemaType) {
+  async create(data, schemaType) {
     if (data.price == undefined) {
       throw "You must include a price"
     }
@@ -48,9 +48,9 @@ module.exports = {
       { formData: data },
       schemaType
     )
-  },
+  }
 
-  buy: async function(listingAddress, unitsToBuy, ethToPay) {
+  async buy(listingAddress, unitsToBuy, ethToPay) {
     return await this.origin.contractService.buyListing(
       listingAddress,
       unitsToBuy,
@@ -58,3 +58,5 @@ module.exports = {
     )
   }
 }
+
+module.exports = Listings

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -2,15 +2,20 @@
 // contractService and ipfsService.
 
 class Listings {
+  constructor({ contractService, ipfsService }) {
+    this.contractService = contractService
+    this.ipfsService = ipfsService
+  }
+
   async allIds() {
-    return await this.origin.contractService.getAllListingIds()
+    return await this.contractService.getAllListingIds()
   }
 
   async getByIndex(listingIndex) {
-    const contractData = await this.origin.contractService.getListing(
+    const contractData = await this.contractService.getListing(
       listingIndex
     )
-    const ipfsData = await this.origin.ipfsService.getFile(
+    const ipfsData = await this.ipfsService.getFile(
       contractData.ipfsHash
     )
     // ipfsService should have already checked the contents match the hash,
@@ -51,7 +56,7 @@ class Listings {
   }
 
   async buy(listingAddress, unitsToBuy, ethToPay) {
-    return await this.origin.contractService.buyListing(
+    return await this.contractService.buyListing(
       listingAddress,
       unitsToBuy,
       ethToPay

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -21,19 +21,19 @@ describe("ContractService", () => {
     })
   })
 
-  describe('blockchain running', () => {
+  describe("blockchain running", () => {
     it(`should should have injected web3 object`, () => {
-      expect('web3' in window).to.equal(true)
+      expect("web3" in window).to.equal(true)
     })
     it(`should be connected to local blockchain`, () => {
       // Will return "connecting" if still waiting for connection,
       // otherwise network number (e.g. 1 for mainnet)
-      const result = (isNaN(web3.version.network))
+      const result = isNaN(web3.version.network)
       expect(result).to.equal(false)
     })
   })
 
-  describe('getBytes32FromIpfsHash', () => {
+  describe("getBytes32FromIpfsHash", () => {
     ipfsHashes.forEach(({ ipfsHash, bytes32 }) => {
       it(`should correctly convert from IPFS hash ${ipfsHash}`, () => {
         const result = contractService.getBytes32FromIpfsHash(ipfsHash)

--- a/packages/origin.js/test/resource_listings.test.js
+++ b/packages/origin.js/test/resource_listings.test.js
@@ -1,29 +1,35 @@
 import { expect } from "chai"
-import Origin from "../src/index.js"
+import Listings from "../src/resources/listings.js"
+import ContractService from "../src/contract-service.js"
+import IpfsService from "../src/ipfs-service.js"
 
 describe("Listing Resource", () => {
-  var origin
+  var listings
+  var contractService
+  var ipfsService
   var testListingIds
 
   before(async () => {
-    origin = Origin // Doing this little dance because eventualy Origin won't be a singleton, but something we instantiate
-    testListingIds = await origin.contractService.getAllListingIds()
+    contractService = new ContractService()
+    ipfsService = new IpfsService()
+    listings = new Listings({ contractService, ipfsService })
+    testListingIds = await contractService.getAllListingIds()
   })
 
   it("should get all listing ids", async () => {
-    const ids = await origin.listings.allIds()
-    expect(ids.length).to.equal(0)
+    const ids = await listings.allIds()
+    expect(ids.length).to.be.greaterThan(4)
   })
 
   it("should get a listing", async () => {
-    const listing = await origin.listings.getByIndex(testListingIds[0])
+    const listing = await listings.getByIndex(testListingIds[0])
     expect(listing.name).to.equal("Zinc House")
     expect(listing.index).to.equal(testListingIds[0])
   })
 
   it("should buy a listing", async () => {
-    const listing = await origin.listings.getByIndex(testListingIds[0])
-    const transaction = await origin.listings.buy(
+    const listing = await listings.getByIndex(testListingIds[0])
+    const transaction = await listings.buy(
       listing.address,
       1,
       listing.price * 1
@@ -44,7 +50,7 @@ describe("Listing Resource", () => {
       price: 3.3
     }
     const schema = "for-sale"
-    await origin.listings.create(listingData, schema)
+    await listings.create(listingData, schema)
     // Todo: Check that this worked after we have web3 approvals working
   })
 })


### PR DESCRIPTION
Note: this is a breaking change. https://github.com/OriginProtocol/demo-dapp/pull/104 updates the demo-dapp to accomodate this change.

This is a restructure of the way things are being exported in origin.js. It solves a couple problems using (what I believe are) best practices around modularization. On top of solving these problems I think it will make development more maintainable in the long run.

Immediate problems being solved:

1. Cannot currently initialize origin.js with config options
2. Tests are currently dependent on web3; difficult to run unit tests on individual origin.js services/modules by stubbing out dependencies

For example, one important thing that happens here is that we no longer have this shared `origin` object being accessed across modules by reference. Having this object introduced the assumption that all of these modules will always be used with one another - making it difficult to swap out or stub out dependencies (which makes testing difficult, as we've seen with the web3 dependency).

This solves (1) completely and makes progress towards solving (2), although after discussion I've removed commits that change our test structure for now.
