### PR TITLE
Testing without metamask

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -26,6 +26,21 @@ test
 
 To show the gas costs of each transaction during a test, set the enviroment variable `GAS_TRACKING` before launching `truffle develop`. For example, using bash: `GAS_TRACKING=1 npx truffle develop`.
 
+## Using Seed Data
+
+In terminal
+```
+npx truffle develop
+```
+and then at prompt type:
+```
+migrate --reset
+```
+and then
+```
+exec scripts/seed.js
+```
+
 ### Rinkeby, Ropsten, Main, and other blockchains
 ```
 npx truffle test

--- a/packages/contracts/contracts/ListingsRegistry.sol
+++ b/packages/contracts/contracts/ListingsRegistry.sol
@@ -49,60 +49,6 @@ contract ListingsRegistry {
   {
     // Defines origin admin address - may be removed for public deployment
     owner = msg.sender;
-
-    // Sample Listings - May be removed for public deployment
-    // 2018-04-04 - Temp commented out to get under gas limit.
-    // testingAddSampleListings();
-  }
-
-  function testingAddSampleListings()
-    public
-    isOwner
-  {
-    // We get stripped hex value from IPFS hash using getBytes32FromIpfsHash()
-    // in contract-service.js
-
-    // Zinc house - Hash: QmTfozaMrUBZdYBzPgxuSC15zBRgLCEfQmWFZwmDHYGY1e
-    create(
-      0x4f32f7a7d40b4d65a917926cbfd8fd521483e7472bcc4d024179735622447dc9,
-      3.999 ether, 1
-    );
-
-    // Scout II - Hash: QmZD8wZWEqzKwvEtGWXzCb3MuXvmxLdCxXGHMRocQFnpoy
-    create(
-      0xa183d4eb3552e730c2dd3df91384426eb88879869b890ad12698320d8b88cb48,
-      0.600 ether, 1
-    );
-
-    // Mamalahoa Estate - Hash: QmZtQDL4UjQWryQLjsS5JUsbdbn2B27Tmvz2gvLkw7wmmb
-    create(
-      0xab92c0500ba26fa6f5244f8ba54746e15dd455a7c99a67f0e8f8868c8fab4a1a,
-      8.500 ether, 1
-    );
-
-    // Casa Wolf - Hash: QmVYeipL2JWFkpWsGqNNXDFUVAmPWEEK8u3Q45CZ1YrZPf
-    create(
-      0x6b14cac30356789cd0c39fec0acc2176c3573abdb799f3b17ccc6972ab4d39ba,
-      1.500 ether, 1
-    );
-
-    // Taylor Swift - Hash: QmfXRgtSbrGggApvaFCa88ofeNQP79G18DpWaSW1Wya1u8
-    create(
-      0xff5957ff4035d28dcee79e65aa4124a4de4dcc8cb028faca54c883a5497d8917,
-      0.300 ether, 25
-    );
-
-    // // Red shoe - Hash: QmfF4JBA4fEYDkZqjRHnDxWGGoXg5D1T4WqfDrN4GXP33p
-    // create(
-    //   0xfb27dcfe2c7febe98d755e2f9df0ff73fb8abecaa778f540d0cbf28b059306db,
-    //   0.01 ether, 1
-    // );
-
-    // // Lambo - Hash: QmYsNo3fYTXQRHREYeoGUGLuYETnjx3HxQFMeiZuE7zPSf
-    // create(
-    //   0x9c73e11ffa575504295be4ece1d4ea49df33261f8eb6a4a7e313e4bb74abf150,
-    //   2.50 ether, 1
-    // );
   }
 
   /// @dev listingsLength(): Return number of listings

--- a/packages/contracts/package-lock.json
+++ b/packages/contracts/package-lock.json
@@ -706,6 +706,31 @@
         "uuid": "2.0.3"
       }
     },
+    "ethjs-abi": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
+      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        }
+      }
+    },
     "ethjs-util": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
@@ -5499,6 +5524,24 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        }
+      }
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -6135,6 +6178,62 @@
         "mocha": "3.5.3",
         "original-require": "1.0.1",
         "solc": "0.4.19"
+      }
+    },
+    "truffle-blockchain-utils": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.1.tgz",
+      "integrity": "sha1-B6WOVbsFVaZCCMkRnAsE/+FGSqQ=",
+      "dev": true,
+      "requires": {
+        "web3": "0.18.4"
+      }
+    },
+    "truffle-contract": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-1.1.11.tgz",
+      "integrity": "sha1-zh+nh/eXdYr/Vy9F6LEXRSf27ao=",
+      "dev": true,
+      "requires": {
+        "ethjs-abi": "0.1.8",
+        "truffle-blockchain-utils": "0.0.1",
+        "truffle-contract-schema": "0.0.5",
+        "web3": "0.16.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+          "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xmlhttprequest": "1.8.0"
+          }
+        }
+      }
+    },
+    "truffle-contract-schema": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-0.0.5.tgz",
+      "integrity": "sha1-Xp0gvQvyon/pQxB0gknUhO7kmWE=",
+      "dev": true,
+      "requires": {
+        "crypto-js": "3.1.9-1"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "3.1.9-1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+          "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+          "dev": true
+        }
       }
     },
     "truffle-hdwallet-provider": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "prettier": "1.11.1",
     "truffle": "^4.1.3",
+    "truffle-contract": "^1.1.8",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {

--- a/packages/contracts/scripts/seed.js
+++ b/packages/contracts/scripts/seed.js
@@ -1,0 +1,56 @@
+var ListingsRegistryContract = require("../../contracts/build/contracts/ListingsRegistry.json")
+var contract = require("truffle-contract")
+
+module.exports = function(callback) {
+  let deployed
+  let listingRegistryContract = contract(ListingsRegistryContract)
+  listingRegistryContract.setProvider(web3.currentProvider)
+  listingRegistryContract.deployed()
+  .then((deployedContract) => {
+    deployed = deployedContract
+    return deployed.create(
+      "0x4f32f7a7d40b4d65a917926cbfd8fd521483e7472bcc4d024179735622447dc9",
+      3.999,
+      1,
+      { from: web3.eth.accounts[0], gas: 4476768 }
+    )
+  })
+  .then(() => {
+    return deployed.create(
+      "0xa183d4eb3552e730c2dd3df91384426eb88879869b890ad12698320d8b88cb48",
+      0.600,
+      1,
+      { from: web3.eth.accounts[0], gas: 4476768 }
+    )
+  })
+  .then(() => {
+    return deployed.create(
+      "0xab92c0500ba26fa6f5244f8ba54746e15dd455a7c99a67f0e8f8868c8fab4a1a",
+      8.500,
+      1,
+      { from: web3.eth.accounts[0], gas: 4476768 }
+    )
+  })
+  .then(() => {
+    return deployed.create(
+      "0x6b14cac30356789cd0c39fec0acc2176c3573abdb799f3b17ccc6972ab4d39ba",
+      1.500,
+      1,
+      { from: web3.eth.accounts[0], gas: 4476768 }
+    )
+  })
+  .then(() => {
+    return deployed.create(
+      "0xff5957ff4035d28dcee79e65aa4124a4de4dcc8cb028faca54c883a5497d8917",
+      0.300,
+      25,
+      { from: web3.eth.accounts[0], gas: 4476768 }
+    )
+  })
+  .then(() => {
+    callback("Seeded successfully")
+  })
+  .catch((error) => {
+    callback(error)
+  })
+}

--- a/packages/origin.js/package-lock.json
+++ b/packages/origin.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@originprotocol/origin",
-  "version": "0.2.50",
+  "version": "0.2.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12581,6 +12581,22 @@
         "truffle-blockchain-utils": "0.0.1",
         "truffle-contract-schema": "0.0.5",
         "web3": "0.16.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+        },
+        "web3": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+          "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+          "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xmlhttprequest": "1.8.0"
+          }
+        }
       }
     },
     "truffle-contract-schema": {
@@ -13050,18 +13066,21 @@
       }
     },
     "web3": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-      "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+      "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
+      "dev": true,
       "requires": {
-        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "3.1.8",
         "utf8": "2.1.2",
+        "xhr2": "0.1.4",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "dev": true
         }
       }
     },

--- a/packages/origin.js/package.json
+++ b/packages/origin.js/package.json
@@ -50,6 +50,7 @@
     "mocha-loader": "^1.1.3",
     "prettier": "1.11.1",
     "sinon": "^2.4.1",
+    "web3": "^0.20.1",
     "webpack": "^3.4.1",
     "webpack-dev-server": "^2.11.2",
     "webpack-node-externals": "^1.6.0"

--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -56,7 +56,7 @@ class ContractService {
         this.getBytes32FromIpfsHash(ipfsListing),
         weiToGive,
         units,
-        { from: accounts[0] }
+        { from: accounts[0], gas: 4476768 }
       )
     } catch (error) {
       console.error("Error submitting to the Ethereum blockchain: " + error)

--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -99,8 +99,7 @@ class ContractService {
     try {
       listing = await instance.getListing.call(listingId)
     } catch (error) {
-      console.log(`Error fetching listingId: ${listingId}`)
-      throw error
+      throw new Error(`Error fetching listingId: ${listingId}`)
     }
 
     // Listing is returned as array of properties.

--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -6,10 +6,11 @@ import contract from "truffle-contract"
 import promisify from "util.promisify"
 
 class ContractService {
-  constructor() {
+  constructor({ web3 } = {}) {
     this.listingsRegistryContract = contract(ListingsRegistryContract)
     this.listingContract = contract(ListingContract)
     this.userRegistryContract = contract(UserRegistryContract)
+    this.web3 = web3 || window.web3
   }
 
   // Return bytes32 hex string from base58 encoded ipfs hash,
@@ -42,13 +43,13 @@ class ContractService {
 
   async submitListing(ipfsListing, ethPrice, units) {
     try {
-      const { currentProvider, eth } = window.web3
+      const { currentProvider, eth } = this.web3
       this.listingsRegistryContract.setProvider(currentProvider)
 
       const accounts = await promisify(eth.getAccounts.bind(eth))()
       const instance = await this.listingsRegistryContract.deployed()
 
-      const weiToGive = window.web3.toWei(ethPrice, "ether")
+      const weiToGive = this.web3.toWei(ethPrice, "ether")
       // Note we cannot get the listingId returned by our contract.
       // See: https://forum.ethereum.org/discussion/comment/31529/#Comment_31529
       return instance.create(
@@ -67,7 +68,7 @@ class ContractService {
     const range = (start, count) =>
       Array.apply(0, Array(count)).map((element, index) => index + start)
 
-    this.listingsRegistryContract.setProvider(window.web3.currentProvider)
+    this.listingsRegistryContract.setProvider(this.web3.currentProvider)
 
     let instance
     try {
@@ -91,7 +92,7 @@ class ContractService {
   }
 
   async getListing(listingId) {
-    this.listingsRegistryContract.setProvider(window.web3.currentProvider)
+    this.listingsRegistryContract.setProvider(this.web3.currentProvider)
     const instance = await this.listingsRegistryContract.deployed()
 
     let listing
@@ -111,7 +112,7 @@ class ContractService {
       address: listing[0],
       lister: listing[1],
       ipfsHash: this.getIpfsHashFromBytes32(listing[2]),
-      price: window.web3.fromWei(listing[3], "ether").toNumber(),
+      price: this.web3.fromWei(listing[3], "ether").toNumber(),
       unitsAvailable: listing[4].toNumber()
     }
     return listingObject
@@ -128,12 +129,12 @@ class ContractService {
         ethToGive
     )
 
-    const { currentProvider, eth } = window.web3
+    const { currentProvider, eth } = this.web3
     this.listingContract.setProvider(currentProvider)
 
     const accounts = await promisify(eth.getAccounts.bind(eth))()
     const listing = await this.listingContract.at(listingAddress)
-    const weiToGive = window.web3.toWei(ethToGive, "ether")
+    const weiToGive = this.web3.toWei(ethToGive, "ether")
 
     const transactionReceipt = await listing.buyListing(
       unitsToBuy,
@@ -157,7 +158,7 @@ class ContractService {
         pollIntervalMilliseconds
       )
       function txCheckTimerCallback() {
-        window.web3.eth.getTransaction(
+        this.web3.eth.getTransaction(
           transactionHash,
           (error, transaction) => {
             if (transaction.blockNumber != null) {
@@ -170,7 +171,7 @@ class ContractService {
 
               // // TODO (Stan): Metamask web3 doesn't have this method. Probably could fix by
               // // by doing the "copy local web3 over metamask's" technique.
-              // window.web3.eth.getTransactionReceipt(this.props.transactionHash, (error, transactionHash) => {
+              // this.web3.eth.getTransactionReceipt(this.props.transactionHash, (error, transactionHash) => {
               //   console.log(transactionHash)
               // })
 

--- a/packages/origin.js/src/index.js
+++ b/packages/origin.js/src/index.js
@@ -1,34 +1,29 @@
-// const contractService = require('./contract-service')
-// const ipfsService = require('./ipfs-service')
-// const originService = require('./origin-service')
-
 import ContractService from "./contract-service"
 import IpfsService from "./ipfs-service"
 import OriginService from "./origin-service"
 import UserRegistryService from "./user-registry-service"
 
-const contractService = new ContractService()
-const ipfsService = new IpfsService()
-const originService = new OriginService({ contractService, ipfsService })
-const userRegistryService = new UserRegistryService()
-
-var origin = {
-  contractService: contractService,
-  ipfsService: ipfsService,
-  originService: originService,
-  userRegistryService: userRegistryService
-}
-
 var resources = {
   listings: require("./resources/listings")
 }
 
-// Give each resource access to the origin services.
-// By having a single origin, its configuration can be changed
-// and all contracts will follow it
-for (var resourceName in resources) {
-  resources[resourceName].origin = origin
-  origin[resourceName] = resources[resourceName]
+class Origin {
+  constructor() {
+    // Give each resource access to the origin services.
+    // By having a single origin, its configuration can be changed
+    // and all contracts will follow it
+    for (let resourceName in resources) {
+      resources[resourceName].origin = this
+      this[resourceName] = resources[resourceName]
+    }
+    this.contractService = new ContractService()
+    this.ipfsService = new IpfsService()
+    this.originService = new OriginService({
+      contractService: this.contractService,
+      ipfsService: this.ipfsService
+    })
+    this.userRegistryService = new UserRegistryService()
+  }
 }
 
-module.exports = origin
+module.exports = Origin

--- a/packages/origin.js/src/index.js
+++ b/packages/origin.js/src/index.js
@@ -9,13 +9,6 @@ var resources = {
 
 class Origin {
   constructor() {
-    // Give each resource access to the origin services.
-    // By having a single origin, its configuration can be changed
-    // and all contracts will follow it
-    for (let resourceName in resources) {
-      resources[resourceName].origin = this
-      this[resourceName] = resources[resourceName]
-    }
     this.contractService = new ContractService()
     this.ipfsService = new IpfsService()
     this.originService = new OriginService({
@@ -23,6 +16,15 @@ class Origin {
       ipfsService: this.ipfsService
     })
     this.userRegistryService = new UserRegistryService()
+
+    // Instantiate each resource and give it access to contracts and IPFS
+    for (let resourceName in resources) {
+      let Resource = resources[resourceName]
+      this[resourceName] = new Resource({
+        contractService: this.contractService,
+        ipfsService: this.ipfsService
+      })
+    }
   }
 }
 

--- a/packages/origin.js/src/index.js
+++ b/packages/origin.js/src/index.js
@@ -1,6 +1,5 @@
 import ContractService from "./contract-service"
 import IpfsService from "./ipfs-service"
-import OriginService from "./origin-service"
 import UserRegistryService from "./user-registry-service"
 
 var resources = {
@@ -11,10 +10,8 @@ class Origin {
   constructor() {
     this.contractService = new ContractService()
     this.ipfsService = new IpfsService()
-    this.originService = new OriginService({
-      contractService: this.contractService,
-      ipfsService: this.ipfsService
-    })
+
+    // TODO: This service is deprecated. Remove once the demo dapp no longer depends on it.
     this.userRegistryService = new UserRegistryService()
 
     // Instantiate each resource and give it access to contracts and IPFS

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -49,10 +49,42 @@ class Listings {
     if (data.name == undefined) {
       throw "You must include a name"
     }
-    return this.origin.originService.submitListing(
-      { formData: data },
-      schemaType
-    )
+
+    let formListing = { formData: data }
+
+    // TODO: Why can't we take schematype from the formListing object?
+    const jsonBlob = {
+      'schema': `http://localhost:3000/schemas/${schemaType}.json`,
+      'data': formListing.formData,
+    }
+
+    let ipfsHash
+    try {
+      // Submit to IPFS
+      ipfsHash = await this.ipfsService.submitFile(jsonBlob)
+    } catch (error) {
+      throw new Error(`IPFS Failure: ${error}`)
+    }
+
+    console.log(`IPFS file created with hash: ${ipfsHash} for data:`)
+    console.log(jsonBlob)
+
+    // Submit to ETH contract
+    const units = 1 // TODO: Allow users to set number of units in form
+    let transactionReceipt
+    try {
+      transactionReceipt = await this.contractService.submitListing(
+        ipfsHash,
+        formListing.formData.price,
+        units)
+    } catch (error) {
+      console.error(error)
+      throw new Error(`ETH Failure: ${error}`)
+    }
+
+    // Success!
+    console.log(`Submitted to ETH blockchain with transactionReceipt.tx: ${transactionReceipt.tx}`)
+    return transactionReceipt
   }
 
   async buy(listingAddress, unitsToBuy, ethToPay) {

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -1,12 +1,12 @@
 // For now, we are just wrapping the methods that are already in
 // contractService and ipfsService.
 
-module.exports = {
-  allIds: async function() {
+class Listings {
+  async allIds() {
     return await this.origin.contractService.getAllListingIds()
-  },
+  }
 
-  getByIndex: async function(listingIndex) {
+  async getByIndex(listingIndex) {
     const contractData = await this.origin.contractService.getListing(
       listingIndex
     )
@@ -35,9 +35,9 @@ module.exports = {
     // TODO: Validation
 
     return listing
-  },
+  }
 
-  create: async function(data, schemaType) {
+  async create(data, schemaType) {
     if (data.price == undefined) {
       throw "You must include a price"
     }
@@ -48,9 +48,9 @@ module.exports = {
       { formData: data },
       schemaType
     )
-  },
+  }
 
-  buy: async function(listingAddress, unitsToBuy, ethToPay) {
+  async buy(listingAddress, unitsToBuy, ethToPay) {
     return await this.origin.contractService.buyListing(
       listingAddress,
       unitsToBuy,
@@ -58,3 +58,5 @@ module.exports = {
     )
   }
 }
+
+module.exports = Listings

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -2,15 +2,20 @@
 // contractService and ipfsService.
 
 class Listings {
+  constructor({ contractService, ipfsService }) {
+    this.contractService = contractService
+    this.ipfsService = ipfsService
+  }
+
   async allIds() {
-    return await this.origin.contractService.getAllListingIds()
+    return await this.contractService.getAllListingIds()
   }
 
   async getByIndex(listingIndex) {
-    const contractData = await this.origin.contractService.getListing(
+    const contractData = await this.contractService.getListing(
       listingIndex
     )
-    const ipfsData = await this.origin.ipfsService.getFile(
+    const ipfsData = await this.ipfsService.getFile(
       contractData.ipfsHash
     )
     // ipfsService should have already checked the contents match the hash,
@@ -51,7 +56,7 @@ class Listings {
   }
 
   async buy(listingAddress, unitsToBuy, ethToPay) {
-    return await this.origin.contractService.buyListing(
+    return await this.contractService.buyListing(
       listingAddress,
       unitsToBuy,
       ethToPay

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -16,6 +16,13 @@ describe("ContractService", () => {
     let provider = new Web3.providers.HttpProvider('http://localhost:9545')
     let web3 = new Web3(provider)
     contractService = new ContractService({ web3 })
+
+    // Ensure that there is at least 1 sample listing
+    await contractService.submitListing(
+      "Qmbjig3cZbUUufWqCEFzyCppqdnmQj3RoDjJWomnqYGy1f",
+      "0.00001",
+      1
+    )
   })
 
   methodNames.forEach(methodName => {

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -33,18 +33,6 @@ describe("ContractService", function() {
     })
   })
 
-  describe("blockchain running", () => {
-    it(`should should have injected web3 object`, () => {
-      expect("web3" in window).to.equal(true)
-    })
-    it(`should be connected to local blockchain`, () => {
-      // Will return "connecting" if still waiting for connection,
-      // otherwise network number (e.g. 1 for mainnet)
-      const result = isNaN(web3.version.network)
-      expect(result).to.equal(false)
-    })
-  })
-
   describe("getBytes32FromIpfsHash", () => {
     ipfsHashes.forEach(({ ipfsHash, bytes32 }) => {
       it(`should correctly convert from IPFS hash ${ipfsHash}`, () => {

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -9,7 +9,9 @@ const methodNames = [
   "getIpfsHashFromBytes32"
 ]
 
-describe("ContractService", () => {
+describe("ContractService", function() {
+  this.timeout(5000) // default is 2000
+
   let contractService
 
   before(async () => {
@@ -65,7 +67,7 @@ describe("ContractService", () => {
     // Skipped by default because it pops up MetaMask confirmation dialogue every time you make a
     // change which slows down dev. Should add alternate tests that mock MetaMask and only enable
     // this one as part of manual testing before releases to ensure library works with MetaMask.
-    xit("should successfully submit listing", async () => {
+    it("should successfully submit listing", async () => {
       await contractService.submitListing(
         "Qmbjig3cZbUUufWqCEFzyCppqdnmQj3RoDjJWomnqYGy1f",
         "0.00001",
@@ -84,7 +86,7 @@ describe("ContractService", () => {
 
   describe("getListing", () => {
     // Skipped because of https://github.com/OriginProtocol/platform/issues/27
-    xit("should reject when listing cannot be found", done => {
+    it("should reject when listing cannot be found", done => {
       contractService.getListing("foo").then(done.fail, error => {
         expect(error).to.match(/Error fetching listingId/)
         done()

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -21,19 +21,19 @@ describe("ContractService", () => {
     })
   })
 
-  describe('blockchain running', () => {
+  describe("blockchain running", () => {
     it(`should should have injected web3 object`, () => {
-      expect('web3' in window).to.equal(true)
+      expect("web3" in window).to.equal(true)
     })
     it(`should be connected to local blockchain`, () => {
       // Will return "connecting" if still waiting for connection,
       // otherwise network number (e.g. 1 for mainnet)
-      const result = (isNaN(web3.version.network))
+      const result = isNaN(web3.version.network)
       expect(result).to.equal(false)
     })
   })
 
-  describe('getBytes32FromIpfsHash', () => {
+  describe("getBytes32FromIpfsHash", () => {
     ipfsHashes.forEach(({ ipfsHash, bytes32 }) => {
       it(`should correctly convert from IPFS hash ${ipfsHash}`, () => {
         const result = contractService.getBytes32FromIpfsHash(ipfsHash)

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import ContractService from "../src/contract-service"
 import { ipfsHashes } from "./fixtures"
+import Web3 from 'web3'
 
 const methodNames = [
   "submitListing",
@@ -12,7 +13,9 @@ describe("ContractService", () => {
   let contractService
 
   beforeEach(() => {
-    contractService = new ContractService()
+    let provider = new Web3.providers.HttpProvider('http://localhost:9545')
+    let web3 = new Web3(provider)
+    contractService = new ContractService({ web3 })
   })
 
   methodNames.forEach(methodName => {

--- a/packages/origin.js/test/contract-service.test.js
+++ b/packages/origin.js/test/contract-service.test.js
@@ -12,7 +12,7 @@ const methodNames = [
 describe("ContractService", () => {
   let contractService
 
-  beforeEach(() => {
+  before(async () => {
     let provider = new Web3.providers.HttpProvider('http://localhost:9545')
     let web3 = new Web3(provider)
     contractService = new ContractService({ web3 })

--- a/packages/origin.js/test/resource_listings.test.js
+++ b/packages/origin.js/test/resource_listings.test.js
@@ -19,29 +19,34 @@ describe("Listing Resource", function() {
     ipfsService = new IpfsService()
     listings = new Listings({ contractService, ipfsService })
     testListingIds = await contractService.getAllListingIds()
+
+    // Ensure that there are at least 2 sample listings
+    await listings.create({ name: "Sample Listing 1", price: 1 }, "")
+    await listings.create({ name: "Sample Listing 2", price: 1 }, "")
   })
 
   it("should get all listing ids", async () => {
     const ids = await listings.allIds()
-    expect(ids.length).to.be.greaterThan(4)
+    expect(ids.length).to.be.greaterThan(1)
   })
 
   it("should get a listing", async () => {
-    const listing = await listings.getByIndex(testListingIds[0])
-    expect(listing.name).to.equal("Zinc House")
-    expect(listing.index).to.equal(testListingIds[0])
+    await listings.create({ name: "Foo Bar", price: 1 }, "")
+    let listingIds = await contractService.getAllListingIds()
+    const listing = await listings.getByIndex(listingIds[listingIds.length - 1])
+    expect(listing.name).to.equal("Foo Bar")
+    expect(listing.index).to.equal(listingIds.length - 1)
   })
 
   it("should buy a listing", async () => {
-    const listing = await listings.getByIndex(testListingIds[0])
+    await listings.create({ name: "My Listing", price: 1 }, "")
+    let listingIds = await contractService.getAllListingIds()
+    const listing = await listings.getByIndex(listingIds[listingIds.length - 1])
     const transaction = await listings.buy(
       listing.address,
       1,
       listing.price * 1
     )
-    //Todo: Currently this test will fail here with a timeout
-    //  because we need to somehow get web3 approve this transaction
-    // Todo: wait for transaction, then check that purchase was created.
   })
 
   it("should create a listing", async () => {

--- a/packages/origin.js/test/resource_listings.test.js
+++ b/packages/origin.js/test/resource_listings.test.js
@@ -1,29 +1,35 @@
 import { expect } from "chai"
-import Origin from "../src/index.js"
+import Listings from "../src/resources/listings.js"
+import ContractService from "../src/contract-service.js"
+import IpfsService from "../src/ipfs-service.js"
 
 describe("Listing Resource", () => {
-  var origin
+  var listings
+  var contractService
+  var ipfsService
   var testListingIds
 
   before(async () => {
-    origin = Origin // Doing this little dance because eventualy Origin won't be a singleton, but something we instantiate
-    testListingIds = await origin.contractService.getAllListingIds()
+    contractService = new ContractService()
+    ipfsService = new IpfsService()
+    listings = new Listings({ contractService, ipfsService })
+    testListingIds = await contractService.getAllListingIds()
   })
 
   it("should get all listing ids", async () => {
-    const ids = await origin.listings.allIds()
-    expect(ids.length).to.equal(0)
+    const ids = await listings.allIds()
+    expect(ids.length).to.be.greaterThan(4)
   })
 
   it("should get a listing", async () => {
-    const listing = await origin.listings.getByIndex(testListingIds[0])
+    const listing = await listings.getByIndex(testListingIds[0])
     expect(listing.name).to.equal("Zinc House")
     expect(listing.index).to.equal(testListingIds[0])
   })
 
   it("should buy a listing", async () => {
-    const listing = await origin.listings.getByIndex(testListingIds[0])
-    const transaction = await origin.listings.buy(
+    const listing = await listings.getByIndex(testListingIds[0])
+    const transaction = await listings.buy(
       listing.address,
       1,
       listing.price * 1
@@ -44,7 +50,7 @@ describe("Listing Resource", () => {
       price: 3.3
     }
     const schema = "for-sale"
-    await origin.listings.create(listingData, schema)
+    await listings.create(listingData, schema)
     // Todo: Check that this worked after we have web3 approvals working
   })
 })

--- a/packages/origin.js/test/resource_listings.test.js
+++ b/packages/origin.js/test/resource_listings.test.js
@@ -5,6 +5,7 @@ import IpfsService from "../src/ipfs-service.js"
 import Web3 from 'web3'
 
 describe("Listing Resource", function() {
+  this.timeout(5000) // default is 2000
 
   var listings
   var contractService
@@ -41,7 +42,7 @@ describe("Listing Resource", function() {
     //Todo: Currently this test will fail here with a timeout
     //  because we need to somehow get web3 approve this transaction
     // Todo: wait for transaction, then check that purchase was created.
-  }).timeout(5000)
+  })
 
   it("should create a listing", async () => {
     const listingData = {

--- a/packages/origin.js/test/resource_listings.test.js
+++ b/packages/origin.js/test/resource_listings.test.js
@@ -2,15 +2,19 @@ import { expect } from "chai"
 import Listings from "../src/resources/listings.js"
 import ContractService from "../src/contract-service.js"
 import IpfsService from "../src/ipfs-service.js"
+import Web3 from 'web3'
 
-describe("Listing Resource", () => {
+describe("Listing Resource", function() {
+
   var listings
   var contractService
   var ipfsService
   var testListingIds
 
   before(async () => {
-    contractService = new ContractService()
+    let provider = new Web3.providers.HttpProvider('http://localhost:9545')
+    let web3 = new Web3(provider)
+    contractService = new ContractService({ web3 })
     ipfsService = new IpfsService()
     listings = new Listings({ contractService, ipfsService })
     testListingIds = await contractService.getAllListingIds()


### PR DESCRIPTION
Should be reviewed after https://github.com/OriginProtocol/platform/pull/82 is merged (contains those commits).

1. Sets up a seed script so that we don't have to clutter the Listing Registry contract with seed data code
2. Allow our origin.js tests to run in the browser *without metamask*

Next step after this would be to set up a script that can run all the tests from the command line with a single command, and then set up automated testing for pull requests.

<img width="514" alt="screen shot 2018-04-06 at 5 54 51 pm" src="https://user-images.githubusercontent.com/6504519/38449467-63a0acf8-39c4-11e8-82e9-4a0ce37e3a11.png">
