### PR TITLE
✨Shipping Pending stage, contract and API

### DIFF
--- a/packages/contracts/contracts/Purchase.sol
+++ b/packages/contracts/contracts/Purchase.sol
@@ -9,6 +9,7 @@ contract Purchase {
 
   enum Stages {
     AWAITING_PAYMENT, // Buyer hasn't paid full amount yet
+    SHIPPING_PENDING, // Waiting for the seller to ship
     BUYER_PENDING, // Waiting for buyer to confirm receipt
     SELLER_PENDING, // Waiting for seller to confirm all is good
     IN_DISPUTE, // We are in a dispute
@@ -78,7 +79,7 @@ contract Purchase {
   {
     if (this.balance >= listingContract.price()) {
       // Buyer (or their proxy) has paid enough to cover purchase
-      internalStage = Stages.BUYER_PENDING;
+      internalStage = Stages.SHIPPING_PENDING;
       buyerTimout = now + 21 days;
     }
     // Possible that nothing happens, and contract just accumulates sent value
@@ -95,6 +96,14 @@ contract Purchase {
       }
     }
     return internalStage;
+  }
+
+  function sellerConfirmShipped()
+  public
+  isSeller
+  atStage(Stages.SHIPPING_PENDING)
+  {
+      internalStage = Stages.BUYER_PENDING;
   }
 
   function buyerConfirmReceipt()

--- a/packages/contracts/contracts/Purchase.sol
+++ b/packages/contracts/contracts/Purchase.sol
@@ -80,7 +80,6 @@ contract Purchase {
     if (this.balance >= listingContract.price()) {
       // Buyer (or their proxy) has paid enough to cover purchase
       internalStage = Stages.SHIPPING_PENDING;
-      buyerTimout = now + 21 days;
     }
     // Possible that nothing happens, and contract just accumulates sent value
   }
@@ -104,6 +103,7 @@ contract Purchase {
   atStage(Stages.SHIPPING_PENDING)
   {
       internalStage = Stages.BUYER_PENDING;
+      buyerTimout = now + 21 days;
   }
 
   function buyerConfirmReceipt()

--- a/packages/contracts/contracts/Purchase.sol
+++ b/packages/contracts/contracts/Purchase.sol
@@ -114,7 +114,7 @@ contract Purchase {
       internalStage = Stages.SELLER_PENDING;
   }
 
-  function sellerGetPayout()
+  function sellerCollectPayout()
   public
   isSeller
   atStage(Stages.SELLER_PENDING)

--- a/packages/contracts/test/TestPurchase.js
+++ b/packages/contracts/test/TestPurchase.js
@@ -145,7 +145,7 @@ contract("Purchase", accounts => {
 
     // Seller collects
     const sellerBalanceBefore = await web3.eth.getBalance(seller)
-    const payoutTransaction = await instance.sellerGetPayout({
+    const payoutTransaction = await instance.sellerCollectPayout({
       from: seller,
       gasPrice: GAS_PRICE
     })
@@ -234,7 +234,7 @@ contract("Purchase", accounts => {
     })
 
     it("should allow seller to collect their money", async () => {
-      await purchase.sellerGetPayout({ from: seller })
+      await purchase.sellerCollectPayout({ from: seller })
       assert.equal((await purchase.stage()).toNumber(), COMPLETE)
     })
   })

--- a/packages/contracts/test/TestPurchase.js
+++ b/packages/contracts/test/TestPurchase.js
@@ -256,6 +256,7 @@ contract("Purchase", accounts => {
         e => e.event == "ListingPurchased"
       )
       purchase = await Purchase.at(listingPurchasedEvent.args._purchaseContract)
+      await timetravel(60*60) // Some time passes before shipping purchase
       await purchase.sellerConfirmShipped({from: seller})
       assert.equal((await purchase.stage()).toNumber(), BUYER_PENDING)
     })

--- a/packages/origin.js/package.json
+++ b/packages/origin.js/package.json
@@ -16,7 +16,8 @@
     "dist"
   ],
   "prettier": {
-    "semi": false
+    "semi": false,
+    "tabWidth": 2
   },
   "repository": {
     "type": "git",

--- a/packages/origin.js/src/ResourceBase.js
+++ b/packages/origin.js/src/ResourceBase.js
@@ -3,13 +3,34 @@ class ResourceBase {
     this.contractService = contractService
     this.ipfsService = ipfsService
   }
-
-  async contractFn(address, functionName, args = [], value = 0) {
+  /**
+   * Runs a call or transaction on a this resource's smart contract.
+   *
+   * This handles getting the contract, using the correct account,
+   * and building our own response for origin transactions.
+   *
+   * If doing a blockchain call, this returns the data returned by
+   * the contract function.
+   *
+   * If running a transaction, this returns an object with a
+   *   - tx - transaction hash
+   *   - whenFinished - a promise that resolves when the transaction is mined
+   *
+   * @param {string} address - address of the contract
+   * @param {string} functionName - contract function to be run
+   * @param {*[]} args - args for the transaction or call.
+   * @param {{gas: number, value:(number | BigNumber)}} options - transaction options for w3
+   */
+  async contractFn(address, functionName, args = [], options = {}) {
+    // Setup options
+    const opts = Object.assign(options, {}) // clone options
+    opts.from = await this.contractService.currentAccount()
+    // Get contract and run trasaction
     const contractDefinition = this.contractDefinition
     const contract = await contractDefinition.at(address)
-    const account = await this.contractService.currentAccount()
-    args.push({ from: account, value: value })
+    args.push(opts)
     const transaction = await contract[functionName].apply(contract, args)
+    // Decorate transaction with whenFinished promise
     if (transaction.tx != undefined) {
       transaction.whenFinished = async () => {
         await this.contractService.waitTransactionFinished(transaction.tx)

--- a/packages/origin.js/src/ResourceBase.js
+++ b/packages/origin.js/src/ResourceBase.js
@@ -1,0 +1,22 @@
+class ResourceBase {
+  constructor({ contractService, ipfsService }) {
+    this.contractService = contractService
+    this.ipfsService = ipfsService
+  }
+
+  async contractFn(address, functionName, args = [], value = 0) {
+    const contractDefinition = this.contractDefinition
+    const contract = await contractDefinition.at(address)
+    const account = await this.contractService.currentAccount()
+    args.push({ from: account, value: value })
+    const result = await contract[functionName].apply(contract, args)
+    if (result.tx != undefined) {
+      result.whenMined = async () => {
+        await this.contractService.waitTransactionFinished(result.tx)
+      }
+    }
+    return result
+  }
+}
+
+export default ResourceBase

--- a/packages/origin.js/src/ResourceBase.js
+++ b/packages/origin.js/src/ResourceBase.js
@@ -9,13 +9,13 @@ class ResourceBase {
     const contract = await contractDefinition.at(address)
     const account = await this.contractService.currentAccount()
     args.push({ from: account, value: value })
-    const result = await contract[functionName].apply(contract, args)
-    if (result.tx != undefined) {
-      result.whenMined = async () => {
-        await this.contractService.waitTransactionFinished(result.tx)
+    const transaction = await contract[functionName].apply(contract, args)
+    if (transaction.tx != undefined) {
+      transaction.whenFinished = async () => {
+        await this.contractService.waitTransactionFinished(transaction.tx)
       }
     }
-    return result
+    return transaction
   }
 }
 

--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -150,7 +150,7 @@ class ContractService {
   }
 
   async waitTransactionFinished(
-    transactionReceipt,
+    transactionHash,
     pollIntervalMilliseconds = 1000
   ) {
     console.log("Waiting for transaction")
@@ -159,36 +159,30 @@ class ContractService {
       if (!transactionHash) {
         reject(`Invalid transactionHash passed: ${transactionHash}`)
       }
-      let txCheckTimer = setInterval(
-        txCheckTimerCallback,
-        pollIntervalMilliseconds
-      )
-      function txCheckTimerCallback() {
-        this.web3.eth.getTransaction(
-          transactionHash,
-          (error, transaction) => {
-            if (transaction.blockNumber != null) {
-              console.log(
-                `Transaction mined at block ${transaction.blockNumber}`
-              )
-              console.log(transaction)
-              // TODO: Wait maximum number of blocks
-              // TODO: Confirm transaction *sucessful* with getTransactionReceipt()
+      var txCheckTimer
+      let txCheckTimerCallback = () => {
+        this.web3.eth.getTransaction(transactionHash, (error, transaction) => {
+          if (transaction.blockNumber != null) {
+            console.log(`Transaction mined at block ${transaction.blockNumber}`)
+            console.log(transaction)
+            // TODO: Wait maximum number of blocks
+            // TODO (Stan): Confirm transaction *sucessful* with getTransactionReceipt()
 
-              // // TODO (Stan): Metamask web3 doesn't have this method. Probably could fix by
-              // // by doing the "copy local web3 over metamask's" technique.
-              // this.web3.eth.getTransactionReceipt(this.props.transactionHash, (error, transactionHash) => {
-              //   console.log(transactionHash)
-              // })
+            // // TODO (Stan): Metamask web3 doesn't have this method. Probably could fix by
+            // // by doing the "copy local web3 over metamask's" technique.
+            // this.web3.eth.getTransactionReceipt(this.props.transactionHash, (error, transactionHash) => {
+            //   console.log(transactionHash)
+            // })
 
-              clearInterval(txCheckTimer)
-              // Hack to wait two seconds, as results don't seem to be
-              // immediately available.
-              setTimeout(() => resolve(transaction.blockNumber), 2000)
-            }
+            clearInterval(txCheckTimer)
+            // Hack to wait two seconds, as results don't seem to be
+            // immediately available.
+            setTimeout(() => resolve(transaction.blockNumber), 2000)
           }
-        )
+        })
       }
+
+      txCheckTimer = setInterval(txCheckTimerCallback, pollIntervalMilliseconds)
     })
     return blockNumber
   }

--- a/packages/origin.js/src/contract-service.js
+++ b/packages/origin.js/src/contract-service.js
@@ -127,28 +127,6 @@ class ContractService {
     return listingObject
   }
 
-  async buyListing(listingAddress, unitsToBuy, ethToGive) {
-    // TODO: Shouldn't we be passing wei to this function, not eth?
-    console.log(
-      "request to buy listing " +
-        listingAddress +
-        ", for this many units " +
-        unitsToBuy +
-        " units. Total eth to send:" +
-        ethToGive
-    )
-
-    const account = await this.currentAccount()
-    const listing = await this.listingContract.at(listingAddress)
-    const weiToGive = this.web3.toWei(ethToGive, "ether")
-
-    const transactionReceipt = await listing.buyListing(
-      unitsToBuy,
-      { from: account, value: weiToGive, gas: 4476768 } // TODO (SRJ): is gas needed?
-    )
-    return transactionReceipt
-  }
-
   async waitTransactionFinished(
     transactionHash,
     pollIntervalMilliseconds = 1000

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -1,10 +1,11 @@
 // For now, we are just wrapping the methods that are already in
 // contractService and ipfsService.
+import ResourceBase from"../ResourceBase"
 
-class Listings {
+class Listings extends ResourceBase{
   constructor({ contractService, ipfsService }) {
-    this.contractService = contractService
-    this.ipfsService = ipfsService
+    super({ contractService, ipfsService })
+    this.contractDefinition = this.contractService.listingContract
   }
 
   async allIds() {
@@ -95,13 +96,8 @@ class Listings {
     )
   }
 
-  async close(listingAddress) {
-    console.log(`Closing listing ${listingAddress}`)
-    const listingContract = this.contractService.listingContract
-    const listing = await listingContract.at(listingAddress)
-    const account = await this.contractService.currentAccount()
-    const transactionReceipt = await listing.close({ from: account }) 
-    return transactionReceipt
+  async close(address) {
+    return await this.contractFn(address, "close")
   }
 }
 

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -97,6 +97,14 @@ class Listings extends ResourceBase{
   async close(address) {
     return await this.contractFn(address, "close")
   }
+
+  async purchasesLength(address) {
+    return await this.contractFn(address, "purchasesLength")
+  }
+
+  async purchaseAddressByIndex(address, index) {
+    return await this.contractFn(address, "getPurchase", [index])
+  }
 }
 
 module.exports = Listings

--- a/packages/origin.js/src/resources/listings.js
+++ b/packages/origin.js/src/resources/listings.js
@@ -88,12 +88,10 @@ class Listings extends ResourceBase{
     return transactionReceipt
   }
 
-  async buy(listingAddress, unitsToBuy, ethToPay) {
-    return await this.contractService.buyListing(
-      listingAddress,
-      unitsToBuy,
-      ethToPay
-    )
+  async buy(address, unitsToBuy, ethToPay) {
+    // TODO: ethToPay should really be replaced by something that takes Wei.
+    const value = this.contractService.web3.toWei(ethToPay, "ether")
+    return await this.contractFn(address, "buyListing", [unitsToBuy], {value:value, gas: 600000})
   }
 
   async close(address) {

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -2,6 +2,15 @@ class Purchases {
     constructor({ contractService, ipfsService }) {
       this.contractService = contractService
       this.ipfsService = ipfsService
+
+      this.STAGES = {
+        AWAITING_PAYMENT: 0,
+        BUYER_PENDING: 1,
+        SELLER_PENDING: 2,
+        IN_DISPUTE: 3,
+        REVIEW_PERIOD: 4,
+        COMPLETE: 5
+      }
     }
 
     async contractFn(address, functionName, args=[], value=0){

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -5,11 +5,12 @@ class Purchases {
 
     this._STAGES_TO_NUMBER = {
       awaiting_payment: 0,
-      buyer_pending: 1,
-      seller_pending: 2,
-      in_dispute: 3,
-      review_period: 4,
-      complete: 5
+      shipping_pending: 1,
+      buyer_pending: 2,
+      seller_pending: 3,
+      in_dispute: 4,
+      review_period: 5,
+      complete: 6
     }
     this._NUMBERS_TO_STAGE = {}
 
@@ -44,12 +45,16 @@ class Purchases {
     return await this.contractFn(address, "pay", [], amountWei)
   }
 
+  async sellerConfirmShipped(address) {
+    return await this.contractFn(address, "sellerConfirmShipped")
+  }
+
   async buyerConfirmReceipt(address) {
     return await this.contractFn(address, "buyerConfirmReceipt")
   }
 
   async sellerGetPayout(address) {
-    return await this.contractFn(address, "sellerGetPayout")
+    return await this.contractFn(address, "sellerCollectPayout")
   }
 }
 

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -38,7 +38,7 @@ class Purchases extends ResourceBase{
   }
 
   async pay(address, amountWei) {
-    return await this.contractFn(address, "pay", [], amountWei)
+    return await this.contractFn(address, "pay", [], {value:amountWei})
   }
 
   async sellerConfirmShipped(address) {

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -1,4 +1,4 @@
-import ResourceBase from"../ResourceBase"
+import ResourceBase from "../ResourceBase"
 
 const _STAGES_TO_NUMBER = {
   awaiting_payment: 0,
@@ -18,9 +18,7 @@ class Purchases extends ResourceBase{
     
     this.contractDefinition = this.contractService.purchaseContract
 
-    this.STAGES = {}
-    Object.entries(_STAGES_TO_NUMBER).map(([k, v]) => {
-      this.STAGES[k.toUpperCase()] = k
+    Object.entries(_STAGES_TO_NUMBER).forEach(([k, v]) => {
       _NUMBERS_TO_STAGE[v] = k
     })
   }

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -1,64 +1,56 @@
 class Purchases {
-    constructor({ contractService, ipfsService }) {
-      this.contractService = contractService
-      this.ipfsService = ipfsService
-      
-      this._STAGES_TO_NUMBER = {
-        awaiting_payment: 0,
-        buyer_pending: 1,
-        seller_pending: 2,
-        in_dispute: 3,
-        review_period: 4,
-        complete: 5
-      }
-      this._NUMBERS_TO_STAGE = {}
+  constructor({ contractService, ipfsService }) {
+    this.contractService = contractService
+    this.ipfsService = ipfsService
 
-      this.STAGES = {}
-      Object.entries(this._STAGES_TO_NUMBER).map(([k, v]) => {
-        this.STAGES[k.toUpperCase()] = k
-        this._NUMBERS_TO_STAGE[v] = k
-      })
+    this._STAGES_TO_NUMBER = {
+      awaiting_payment: 0,
+      buyer_pending: 1,
+      seller_pending: 2,
+      in_dispute: 3,
+      review_period: 4,
+      complete: 5
     }
+    this._NUMBERS_TO_STAGE = {}
 
-    async contractFn(address, functionName, args=[], value=0){
-        const purchaseContract = this.contractService.purchaseContract
-        const purchase = await purchaseContract.at(address)
-        const account = await this.contractService.currentAccount()
-        args.push({ from: account, value: value })
-        return await purchase[functionName].apply(purchase, args)
-    }
+    this.STAGES = {}
+    Object.entries(this._STAGES_TO_NUMBER).map(([k, v]) => {
+      this.STAGES[k.toUpperCase()] = k
+      this._NUMBERS_TO_STAGE[v] = k
+    })
+  }
 
-    async get(address){
-        const contractData = await this.contractFn(
-            address,
-            'data'
-        )
-        return {
-            address: address,
-            stage: this._NUMBERS_TO_STAGE[contractData[0]],
-            listingAddress: contractData[1],
-            buyerAddress: contractData[2],
-            created: contractData[3],
-            buyerTimout: contractData[4]
-        }
-    }
+  async contractFn(address, functionName, args = [], value = 0) {
+    const purchaseContract = this.contractService.purchaseContract
+    const purchase = await purchaseContract.at(address)
+    const account = await this.contractService.currentAccount()
+    args.push({ from: account, value: value })
+    return await purchase[functionName].apply(purchase, args)
+  }
 
-    async pay(address, amountWei){
-        return await this.contractFn(
-            address,
-            'pay',
-            [],
-            amountWei
-        )
+  async get(address) {
+    const contractData = await this.contractFn(address, "data")
+    return {
+      address: address,
+      stage: this._NUMBERS_TO_STAGE[contractData[0]],
+      listingAddress: contractData[1],
+      buyerAddress: contractData[2],
+      created: contractData[3],
+      buyerTimout: contractData[4]
     }
+  }
 
-    async buyerConfirmReceipt(address){
-        return await this.contractFn( address, 'buyerConfirmReceipt')
-    }
+  async pay(address, amountWei) {
+    return await this.contractFn(address, "pay", [], amountWei)
+  }
 
-    async sellerGetPayout(address){
-        return await this.contractFn( address, 'sellerGetPayout')
-    }
-}  
+  async buyerConfirmReceipt(address) {
+    return await this.contractFn(address, "buyerConfirmReceipt")
+  }
+
+  async sellerGetPayout(address) {
+    return await this.contractFn(address, "sellerGetPayout")
+  }
+}
 
 module.exports = Purchases

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -1,7 +1,11 @@
-class Purchases {
+import ResourceBase from"../ResourceBase"
+
+
+class Purchases extends ResourceBase{
   constructor({ contractService, ipfsService }) {
-    this.contractService = contractService
-    this.ipfsService = ipfsService
+    super({ contractService, ipfsService })
+    
+    this.contractDefinition = this.contractService.purchaseContract
 
     this._STAGES_TO_NUMBER = {
       awaiting_payment: 0,
@@ -13,26 +17,11 @@ class Purchases {
       complete: 6
     }
     this._NUMBERS_TO_STAGE = {}
-
     this.STAGES = {}
     Object.entries(this._STAGES_TO_NUMBER).map(([k, v]) => {
       this.STAGES[k.toUpperCase()] = k
       this._NUMBERS_TO_STAGE[v] = k
     })
-  }
-
-  async contractFn(address, functionName, args = [], value = 0) {
-    const purchaseContract = this.contractService.purchaseContract
-    const purchase = await purchaseContract.at(address)
-    const account = await this.contractService.currentAccount()
-    args.push({ from: account, value: value })
-    const result = await purchase[functionName].apply(purchase, args)
-    if(result.tx != undefined){
-      result.whenMined = async () => {
-        await this.contractService.waitTransactionFinished(result.tx)
-      }
-    }
-    return result
   }
 
   async get(address) {

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -1,6 +1,6 @@
 import ResourceBase from"../ResourceBase"
 
-_STAGES_TO_NUMBER = {
+const _STAGES_TO_NUMBER = {
   awaiting_payment: 0,
   shipping_pending: 1,
   buyer_pending: 2,
@@ -9,7 +9,7 @@ _STAGES_TO_NUMBER = {
   review_period: 5,
   complete: 6
 }
-_NUMBERS_TO_STAGE = {}
+const _NUMBERS_TO_STAGE = {}
 
 
 class Purchases extends ResourceBase{

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -2,15 +2,22 @@ class Purchases {
     constructor({ contractService, ipfsService }) {
       this.contractService = contractService
       this.ipfsService = ipfsService
-
-      this.STAGES = {
-        AWAITING_PAYMENT: 0,
-        BUYER_PENDING: 1,
-        SELLER_PENDING: 2,
-        IN_DISPUTE: 3,
-        REVIEW_PERIOD: 4,
-        COMPLETE: 5
+      
+      this._STAGES_TO_NUMBER = {
+        awaiting_payment: 0,
+        buyer_pending: 1,
+        seller_pending: 2,
+        in_dispute: 3,
+        review_period: 4,
+        complete: 5
       }
+      this._NUMBERS_TO_STAGE = {}
+
+      this.STAGES = {}
+      Object.entries(this._STAGES_TO_NUMBER).map(([k, v]) => {
+        this.STAGES[k.toUpperCase()] = k
+        this._NUMBERS_TO_STAGE[v] = k
+      })
     }
 
     async contractFn(address, functionName, args=[], value=0){
@@ -28,7 +35,7 @@ class Purchases {
         )
         return {
             address: address,
-            stage: contractData[0], // perhaps return a string
+            stage: this._NUMBERS_TO_STAGE[contractData[0]],
             listingAddress: contractData[1],
             buyerAddress: contractData[2],
             created: contractData[3],

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -26,7 +26,13 @@ class Purchases {
     const purchase = await purchaseContract.at(address)
     const account = await this.contractService.currentAccount()
     args.push({ from: account, value: value })
-    return await purchase[functionName].apply(purchase, args)
+    const result = await purchase[functionName].apply(purchase, args)
+    if(result.tx != undefined){
+      result.whenMined = async () => {
+        await this.contractService.waitTransactionFinished(result.tx)
+      }
+    }
+    return result
   }
 
   async get(address) {

--- a/packages/origin.js/src/resources/purchases.js
+++ b/packages/origin.js/src/resources/purchases.js
@@ -1,5 +1,16 @@
 import ResourceBase from"../ResourceBase"
 
+_STAGES_TO_NUMBER = {
+  awaiting_payment: 0,
+  shipping_pending: 1,
+  buyer_pending: 2,
+  seller_pending: 3,
+  in_dispute: 4,
+  review_period: 5,
+  complete: 6
+}
+_NUMBERS_TO_STAGE = {}
+
 
 class Purchases extends ResourceBase{
   constructor({ contractService, ipfsService }) {
@@ -7,20 +18,10 @@ class Purchases extends ResourceBase{
     
     this.contractDefinition = this.contractService.purchaseContract
 
-    this._STAGES_TO_NUMBER = {
-      awaiting_payment: 0,
-      shipping_pending: 1,
-      buyer_pending: 2,
-      seller_pending: 3,
-      in_dispute: 4,
-      review_period: 5,
-      complete: 6
-    }
-    this._NUMBERS_TO_STAGE = {}
     this.STAGES = {}
-    Object.entries(this._STAGES_TO_NUMBER).map(([k, v]) => {
+    Object.entries(_STAGES_TO_NUMBER).map(([k, v]) => {
       this.STAGES[k.toUpperCase()] = k
-      this._NUMBERS_TO_STAGE[v] = k
+      _NUMBERS_TO_STAGE[v] = k
     })
   }
 
@@ -28,7 +29,7 @@ class Purchases extends ResourceBase{
     const contractData = await this.contractFn(address, "data")
     return {
       address: address,
-      stage: this._NUMBERS_TO_STAGE[contractData[0]],
+      stage: _NUMBERS_TO_STAGE[contractData[0]],
       listingAddress: contractData[1],
       buyerAddress: contractData[2],
       created: contractData[3],

--- a/packages/origin.js/test/resource_listings.test.js
+++ b/packages/origin.js/test/resource_listings.test.js
@@ -80,4 +80,24 @@ describe("Listing Resource", function() {
     const listingAfter = await listings.getByIndex(listingIndex)
     expect(listingAfter.unitsAvailable).to.equal(0)
   })
+
+  describe("Getting purchase addresses", async () => {
+    var listing
+    before(async () => {
+      await listings.create({ name: "My Listing", price: 1 }, "")
+      const listingIds = await contractService.getAllListingIds()
+      listing = await listings.getByIndex(listingIds[listingIds.length - 1])
+      const transaction = await listings.buy(listing.address, 1, 1)
+    })
+
+    it("should get the number of purchases", async () => {
+      const numPurchases = await listings.purchasesLength(listing.address)
+      expect(numPurchases.toNumber()).to.equal(1)
+    })
+
+    it("should get the address of a purchase", async () => {
+      const address = await listings.purchaseAddressByIndex(listing.address, 0)
+      expect(address.slice(0, 2)).to.equal("0x")
+    })
+  })
 })

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -86,11 +86,14 @@ describe("Purchase Resource", function() {
         contractService.web3.toWei("0.1", "ether")
       )
       purchase = await purchases.get(purchase.address)
-      expectStage(purchases.STAGES.BUYER_PENDING)
+      expectStage(purchases.STAGES.SHIPPING_PENDING)
     })
 
     it("should allow the seller to mark as shipped", async () => {
-      // Not implimented on the contract yet
+      expectStage(purchases.STAGES.SHIPPING_PENDING)
+      await purchases.sellerConfirmShipped(purchase.address)
+      purchase = await purchases.get(purchase.address)
+      expectStage(purchases.STAGES.BUYER_PENDING)
     })
 
     it("should allow the buyer to mark a purchase received", async () => {

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -66,8 +66,8 @@ describe("Purchase Resource", function() {
   // Tests
   // -----
 
-  describe("stage names ", ()=>{
-    it("should provide the correct stage names", function(){
+  describe("stage names ", () => {
+    it("should provide the correct stage names", function() {
       expect(purchases.STAGES.AWAITING_PAYMENT).to.equal("awaiting_payment")
       expect(purchases.STAGES.SHIPPING_PENDING).to.equal("shipping_pending")
       expect(purchases.STAGES.BUYER_PENDING).to.equal("buyer_pending")

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -66,6 +66,18 @@ describe("Purchase Resource", function() {
   // Tests
   // -----
 
+  describe("stage names ", ()=>{
+    it("should provide the correct stage names", function(){
+      expect(purchases.STAGES.AWAITING_PAYMENT).to.equal("awaiting_payment")
+      expect(purchases.STAGES.SHIPPING_PENDING).to.equal("shipping_pending")
+      expect(purchases.STAGES.BUYER_PENDING).to.equal("buyer_pending")
+      expect(purchases.STAGES.SELLER_PENDING).to.equal("seller_pending")
+      expect(purchases.STAGES.IN_DISPUTE).to.equal("in_dispute")
+      expect(purchases.STAGES.REVIEW_PERIOD).to.equal("review_period")
+      expect(purchases.STAGES.COMPLETE).to.equal("complete")
+    })
+  })
+
   describe("simple purchase flow", async () => {
     before(async () => {
       await resetListingAndPurchase()

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -60,7 +60,7 @@ describe("Purchase Resource", function() {
   }
 
   let expectStage = function(expectedStage) {
-    expect(purchase.stage.toNumber()).to.equal(expectedStage)
+    expect(purchase.stage).to.equal(expectedStage)
   }
 
   // Tests

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -121,7 +121,7 @@ describe("Purchase Resource", function() {
         purchase.address,
         contractService.web3.toWei("0.1", "ether")
       )
-      await transaction.whenMined()
+      await transaction.whenFinished()
     })
   })
 })

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -110,4 +110,18 @@ describe("Purchase Resource", function() {
       expectStage(purchases.STAGES.COMPLETE)
     })
   })
+
+  describe("transactions have a whenMined promise", async () => {
+    before(async () => {
+      await resetListingAndPurchase()
+    })
+
+    it("should allow us to wait for a transaction to be mined", async () => {
+      const transaction = await purchases.pay(
+        purchase.address,
+        contractService.web3.toWei("0.1", "ether")
+      )
+      await transaction.whenMined()
+    })
+  })
 })

--- a/packages/origin.js/test/resource_purchases.test.js
+++ b/packages/origin.js/test/resource_purchases.test.js
@@ -66,25 +66,13 @@ describe("Purchase Resource", function() {
   // Tests
   // -----
 
-  describe("stage names ", () => {
-    it("should provide the correct stage names", function() {
-      expect(purchases.STAGES.AWAITING_PAYMENT).to.equal("awaiting_payment")
-      expect(purchases.STAGES.SHIPPING_PENDING).to.equal("shipping_pending")
-      expect(purchases.STAGES.BUYER_PENDING).to.equal("buyer_pending")
-      expect(purchases.STAGES.SELLER_PENDING).to.equal("seller_pending")
-      expect(purchases.STAGES.IN_DISPUTE).to.equal("in_dispute")
-      expect(purchases.STAGES.REVIEW_PERIOD).to.equal("review_period")
-      expect(purchases.STAGES.COMPLETE).to.equal("complete")
-    })
-  })
-
   describe("simple purchase flow", async () => {
     before(async () => {
       await resetListingAndPurchase()
     })
 
     it("should get a purchase", async () => {
-      expectStage(purchases.STAGES.AWAITING_PAYMENT)
+      expectStage("awaiting_payment")
       expect(purchase.listingAddress).to.equal(listing.address)
       expect(purchase.buyerAddress).to.equal(
         await contractService.currentAccount()
@@ -92,34 +80,34 @@ describe("Purchase Resource", function() {
     })
 
     it("should allow the buyer to pay", async () => {
-      expectStage(purchases.STAGES.AWAITING_PAYMENT)
+      expectStage("awaiting_payment")
       await purchases.pay(
         purchase.address,
         contractService.web3.toWei("0.1", "ether")
       )
       purchase = await purchases.get(purchase.address)
-      expectStage(purchases.STAGES.SHIPPING_PENDING)
+      expectStage("shipping_pending")
     })
 
     it("should allow the seller to mark as shipped", async () => {
-      expectStage(purchases.STAGES.SHIPPING_PENDING)
+      expectStage("shipping_pending")
       await purchases.sellerConfirmShipped(purchase.address)
       purchase = await purchases.get(purchase.address)
-      expectStage(purchases.STAGES.BUYER_PENDING)
+      expectStage("buyer_pending")
     })
 
     it("should allow the buyer to mark a purchase received", async () => {
-      expectStage(purchases.STAGES.BUYER_PENDING)
+      expectStage("buyer_pending")
       await purchases.buyerConfirmReceipt(purchase.address)
       purchase = await purchases.get(purchase.address)
-      expectStage(purchases.STAGES.SELLER_PENDING)
+      expectStage("seller_pending")
     })
 
     it("should allow the seller to collect money", async () => {
-      expectStage(purchases.STAGES.SELLER_PENDING)
+      expectStage("seller_pending")
       await purchases.sellerGetPayout(purchase.address)
       purchase = await purchases.get(purchase.address)
-      expectStage(purchases.STAGES.COMPLETE)
+      expectStage("complete")
     })
   })
 


### PR DESCRIPTION
- Change origin.js to use strings for stages, rather than numbers
- Add new shipping_pending state to contracts, contract tests, origin.js, and origin.js tests
- Add sellerConfirmShip to contracts, contract tests, origin.js, and origin.js tests
- Rename getPayout to collectPayout, since it not a getting data method
- Add PurchaseChance events for Python ingest support